### PR TITLE
corrected the joern-parse command

### DIFF
--- a/src/prepare/cpg_generator.py
+++ b/src/prepare/cpg_generator.py
@@ -28,7 +28,7 @@ def graph_indexing(graph):
 
 def joern_parse(joern_path, input_path, output_path, file_name):
     out_file = file_name + ".bin"
-    joern_parse_call = subprocess.run(["./" + joern_path + "joern-parse", input_path, "--out", output_path + out_file],
+    joern_parse_call = subprocess.run(["./" + joern_path + "joern-parse", input_path, "--output", output_path + out_file],
                                       stdout=subprocess.PIPE, text=True, check=True)
     print(str(joern_parse_call))
     return out_file


### PR DESCRIPTION
joern-parse takes either "-o" or "--output" before the passing the filename argument and  "--out" returns an error.  :-) (It's a small one, but though was crucial)